### PR TITLE
Configure env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Copy this file to `.env.dev` and `.env.prod` and adjust as needed
+
 # Base URL for the Strapi instance used by the frontend
 # Use the production server to avoid running Strapi locally
 STRAPI_URL=https://api.slavalarionov.store

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Base URL for the Strapi instance used by the frontend
+# Use the production server to avoid running Strapi locally
+STRAPI_URL=https://api.slavalarionov.store
+
+# Address of the local PHP backend
+BACKEND_BASE_ADDRESS=http://localhost/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,26 @@ pnpm install
 yarn install
 ```
 
+## Environment variables
+
+Create `.env.dev` or `.env.prod` based on your environment. Use the provided
+`.env.example` as a starting point:
+
+```bash
+cp .env.example .env.dev
+```
+
+By default Nuxt expects Strapi to run locally at `http://localhost:1337`.
+To connect to the production Strapi instance set `STRAPI_URL` in your
+`.env.dev` or `.env.prod`:
+
+```bash
+echo "STRAPI_URL=https://api.slavalarionov.store" >> .env.dev
+```
+
+`BACKEND_BASE_ADDRESS` controls the address for the PHP backend and usually
+points to your local server, e.g. `http://localhost/`.
+
 ## Development Server
 
 Start the development server on `http://localhost:3000`:

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ yarn install
 
 ## Environment variables
 
-Create `.env.dev` or `.env.prod` based on your environment. Use the provided
+Create `.env.dev` for development and `.env.prod` for builds. Use the provided
 `.env.example` as a starting point:
 
 ```bash
 cp .env.example .env.dev
+cp .env.example .env.prod
 ```
 
 By default Nuxt expects Strapi to run locally at `http://localhost:1337`.
@@ -32,6 +33,7 @@ To connect to the production Strapi instance set `STRAPI_URL` in your
 
 ```bash
 echo "STRAPI_URL=https://api.slavalarionov.store" >> .env.dev
+echo "STRAPI_URL=https://api.slavalarionov.store" >> .env.prod
 ```
 
 `BACKEND_BASE_ADDRESS` controls the address for the PHP backend and usually


### PR DESCRIPTION
## Summary
- clarify environment variable setup in README
- provide example .env with production Strapi
- default Strapi URL fallback to local instance

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b452dfddc832ab07d2742ea5d3e40